### PR TITLE
fix(sync): honor default merge strategy

### DIFF
--- a/pkg/github/files.go
+++ b/pkg/github/files.go
@@ -271,10 +271,12 @@ func processFileMapping(
 	var mergeStrategy configtypes.MergeStrategy
 
 	if mergeConfig != nil {
+		effectiveStrategy := effectiveMergeStrategy(mapping.Dest, mergeConfig)
+
 		log.Info(
 			"found merge config for file",
 			"file", mapping.Dest,
-			"strategy", mergeConfig.Strategy,
+			"strategy", effectiveStrategy,
 		)
 
 		// Apply merge
@@ -287,7 +289,7 @@ func processFileMapping(
 		} else {
 			// Use merged content
 			sourceContent = mergedContent
-			mergeStrategy = mergeConfig.Strategy
+			mergeStrategy = effectiveStrategy
 		}
 	}
 
@@ -379,6 +381,23 @@ func processNewFile(
 		Content: sourceContent,
 		Action:  "create",
 	})
+}
+
+func effectiveMergeStrategy(path string, mergeConfig *configtypes.FileMergeConfig) configtypes.MergeStrategy {
+	if mergeConfig == nil {
+		return ""
+	}
+
+	if mergeConfig.Strategy != "" {
+		return mergeConfig.Strategy
+	}
+
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".md" || ext == ".markdown" {
+		return configtypes.MergeStrategyMarkdown
+	}
+
+	return configtypes.MergeStrategyDeep
 }
 
 // shouldSkipRenovateJSON checks if renovate.json should be skipped due to manual modifications.

--- a/pkg/github/files_test.go
+++ b/pkg/github/files_test.go
@@ -3,6 +3,8 @@ package github
 import (
 	"bytes"
 	"testing"
+
+	"github.com/smykla-skalski/.github/internal/configtypes"
 )
 
 func TestRenderFileTemplate(t *testing.T) {
@@ -74,6 +76,56 @@ func TestRenderFileTemplate(t *testing.T) {
 
 			if !bytes.Equal(got, tt.want) {
 				t.Errorf("renderFileTemplate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveMergeStrategy(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		mergeConfig *configtypes.FileMergeConfig
+		want        configtypes.MergeStrategy
+	}{
+		{
+			name: "nil config has no merge strategy",
+			path: "renovate.json",
+			want: "",
+		},
+		{
+			name:        "default JSON strategy is deep merge",
+			path:        "renovate.json",
+			mergeConfig: &configtypes.FileMergeConfig{},
+			want:        configtypes.MergeStrategyDeep,
+		},
+		{
+			name:        "default YAML strategy is deep merge",
+			path:        ".github/settings.yml",
+			mergeConfig: &configtypes.FileMergeConfig{},
+			want:        configtypes.MergeStrategyDeep,
+		},
+		{
+			name:        "default Markdown strategy is markdown",
+			path:        "CONTRIBUTING.md",
+			mergeConfig: &configtypes.FileMergeConfig{},
+			want:        configtypes.MergeStrategyMarkdown,
+		},
+		{
+			name: "explicit strategy wins",
+			path: "renovate.json",
+			mergeConfig: &configtypes.FileMergeConfig{
+				Strategy: configtypes.MergeStrategyShallow,
+			},
+			want: configtypes.MergeStrategyShallow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveMergeStrategy(tt.path, tt.mergeConfig)
+			if got != tt.want {
+				t.Errorf("effectiveMergeStrategy() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix dotsync file sync so merge configs that omit `strategy` still count as merged after the default strategy is applied.

## Root Cause

`renovate.json` in `klaudiush` has a merge config without an explicit `strategy`, which is valid because the schema/default merge behavior is `deep-merge`. The merge itself succeeded, but `processFileMapping` kept `mergeStrategy` empty. Later, `processExistingFile` treated `renovate.json` as unmerged and ran the manual-modification guard, so the file was excluded from sync.

## Changes

- Record the effective merge strategy after successful merge application.
- Default structured files to `deep-merge` and markdown files to `markdown` for sync bookkeeping.
- Add unit coverage for effective merge strategy selection.

## Validation

- `git diff --check -- pkg/github/files.go pkg/github/files_test.go`
- `mise exec -- gofmt -w pkg/github/files.go pkg/github/files_test.go`