### PR TITLE
fix(ci): use create-github-app-token client id

### DIFF
--- a/.github/workflows/release-dotsync.yml
+++ b/.github/workflows/release-dotsync.yml
@@ -94,7 +94,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Wait for sync workflows to complete
@@ -211,7 +211,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Checkout
@@ -364,7 +364,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Re-enable sync workflows

--- a/.github/workflows/smyklot-poll.yml
+++ b/.github/workflows/smyklot-poll.yml
@@ -31,7 +31,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Poll reactions on open PRs

--- a/.github/workflows/smyklot-pr-commands.yml
+++ b/.github/workflows/smyklot-pr-commands.yml
@@ -27,7 +27,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -48,7 +48,7 @@ jobs:
         if: inputs.repo == ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -85,7 +85,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repo.name }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -47,7 +47,7 @@ jobs:
         if: inputs.repo == ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -76,7 +76,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repo.name }}

--- a/.github/workflows/sync-settings.yml
+++ b/.github/workflows/sync-settings.yml
@@ -47,7 +47,7 @@ jobs:
         if: inputs.repo == ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -76,7 +76,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repo.name }}

--- a/.github/workflows/sync-smyklot.yml
+++ b/.github/workflows/sync-smyklot.yml
@@ -58,13 +58,13 @@ jobs:
     steps:
       - name: Validate smyklot configuration
         env:
-          SMYKLOT_APP_ID: ${{ vars.SMYKLOT_APP_ID }}
+          SMYKLOT_CLIENT_ID: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           SMYKLOT_APP_PRIVATE_KEY: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
         run: |
           errors=()
 
-          if [[ -z "$SMYKLOT_APP_ID" ]]; then
-            errors+=("SMYKLOT_APP_ID variable is not set")
+          if [[ -z "$SMYKLOT_CLIENT_ID" ]]; then
+            errors+=("SMYKLOT_CLIENT_ID variable is not set")
           fi
 
           if [[ -z "$SMYKLOT_APP_PRIVATE_KEY" ]]; then
@@ -153,7 +153,7 @@ jobs:
         if: inputs.repo == ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -182,7 +182,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repo.name }}

--- a/.github/workflows/sync-trigger.yml
+++ b/.github/workflows/sync-trigger.yml
@@ -71,7 +71,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: .github

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -45,7 +45,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: .github
@@ -136,7 +136,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: .github

--- a/.github/workflows/verify-schemas.yml
+++ b/.github/workflows/verify-schemas.yml
@@ -35,7 +35,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ sync:
 
 All workflows use **smyklot** GitHub App:
 
-- `vars.SMYKLOT_APP_ID` + `secrets.SMYKLOT_PRIVATE_KEY`
+- `vars.SMYKLOT_CLIENT_ID` (optional) + `secrets.SMYKLOT_APP_PRIVATE_KEY`
 
 ## Go Code
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,11 @@ Workflows use the **smyklot** GitHub App for authentication. The app must be ins
 
 Required org-level configuration:
 
-- `vars.SMYKLOT_APP_ID` - GitHub App ID
-- `secrets.SMYKLOT_PRIVATE_KEY` - GitHub App private key
+- `secrets.SMYKLOT_APP_PRIVATE_KEY` - GitHub App private key
+
+Optional org-level configuration:
+
+- `vars.SMYKLOT_CLIENT_ID` - GitHub App client ID. Workflows default to the public Smyklot client ID when unset.
 
 ## Manual Sync
 

--- a/smyklot-templates/smyklot-poll.yml
+++ b/smyklot-templates/smyklot-poll.yml
@@ -31,7 +31,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Poll reactions on open PRs

--- a/smyklot-templates/smyklot-pr-commands.yml
+++ b/smyklot-templates/smyklot-pr-commands.yml
@@ -27,7 +27,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/templates/.github/workflows/sync-trigger.yml
+++ b/templates/.github/workflows/sync-trigger.yml
@@ -71,7 +71,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
+          client-id: ${{ vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy' }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: .github


### PR DESCRIPTION
## Summary

Replace deprecated `app-id` inputs for `actions/create-github-app-token@v3.2.0` with `client-id` across active workflows, synced templates, and Smyklot templates.

The warnings in run `28945461146` came from `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` in `Generate App Token` steps. The action metadata marks `app-id` deprecated with `Use 'client-id' instead.`

This uses `vars.SMYKLOT_CLIENT_ID || 'Iv23liMyF31aNYay8IXy'`, where the fallback is Smyklot's public GitHub App client ID, so the change does not require a separate org variable before merge.

## Validation

- `mise exec -- actionlint -shellcheck=`
- `mise exec -- task lint:markdown lint:mod`

Full `actionlint` still reports existing shellcheck findings outside this change.
