### PR TITLE
fix(templates): use kind/bug in bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
-labels: ["bug"]
+labels: ["kind/bug"]
 body:
   - type: markdown
     attributes:

--- a/templates/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/templates/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
-labels: ["bug"]
+labels: ["kind/bug"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Motivation

The org Bug Report issue form set `labels: ["bug"]`. Bare `bug` is a GitHub default label - `.github/labels.yml` defines only the `kind/*` family (`kind/bug`, `kind/enhancement`, `kind/documentation`, `kind/question`, `kind/security`), so org label sync never manages it.

Because this repo syncs `templates/` out to every member repo, bugs filed through the form land on a label the tracker does not otherwise use. In `smykla-skalski/harness` that's 3 issues on bare `bug` against 17 on `kind/bug`, and all 3 came from the form.

It's worse in repos that opt into `sync.labels.allow_removal: true` (klaudiush, smyklot, af, research, klaudiu.sh, homebrew-af, .dotfiles, monokai-islands). Label sync has already deleted the bare `bug` label there, so GitHub silently drops it and the form applies no label at all.

## Implementation

- `templates/.github/ISSUE_TEMPLATE/bug_report.yml` - `labels: ["bug"]` -> `labels: ["kind/bug"]`. This is the sync source: `dotsync files discover` walks `templates/` and maps each file to the same relative path in the target, so this copy is what reaches member repos.
- `.github/ISSUE_TEMPLATE/bug_report.yml` - same change. `dotsync repos list --format json` (what the sync workflows use via `get-repos`) does not filter out `.github`, so this repo is a sync target too and the root copy has to track the template or the next files sync just opens a PR to change it.

## Verification

- `kind/bug` is defined in `.github/labels.yml`; label sync uses the same repo list as file sync, so every repo receiving the template also receives the label.
- No repo's `.github/sync-config.yml` excludes `kind/bug` from label sync.
- `config.yml` sets no labels, and `bug_report.yml` is the only issue form - nothing else needed the same fix.
- `labels: ["bug"]` appeared nowhere else in the repo; no workflow, config, or automation keys off the bare label.

Existing issues already carrying bare `bug` are untouched - relabeling those is a separate cleanup.