### PR TITLE
fix(sync): find retired workflows in one call

### DIFF
--- a/pkg/github/files.go
+++ b/pkg/github/files.go
@@ -693,7 +693,16 @@ var retiredWorkflowPaths = []string{
 	legacyWorkflowPollPath,
 }
 
+// workflowsDir is where every workflow lives, and the one listing that answers
+// which retired ones a repository still has.
+const workflowsDir = ".github/workflows"
+
 // checkRetiredWorkflows schedules deletion of any retired workflow still present.
+//
+// One listing of the workflows directory rather than a fetch per retired path.
+// This runs for every repository on every file sync, and it keeps running long
+// after the last repository is clean, so the common answer - nothing to delete -
+// should cost one request rather than one per name ever retired.
 func checkRetiredWorkflows(
 	ctx context.Context,
 	log *logger.Logger,
@@ -702,17 +711,25 @@ func checkRetiredWorkflows(
 	repo string,
 	stats *FileSyncStats,
 ) []FileChange {
+	_, dir, _, err := client.Repositories.GetContents(ctx, org, repo, workflowsDir, nil)
+	if err != nil {
+		// A repository with no workflows at all has nothing to clean up
+		if !isNotFoundError(err) {
+			log.Warn("failed to list workflows", "path", workflowsDir, "error", err)
+		}
+
+		return nil
+	}
+
+	present := make(map[string]struct{}, len(dir))
+	for _, entry := range dir {
+		present[entry.GetPath()] = struct{}{}
+	}
+
 	var changes []FileChange
 
 	for _, path := range retiredWorkflowPaths {
-		_, exists, err := fetchTargetFile(ctx, client, org, repo, path)
-		if err != nil {
-			log.Warn("failed to check retired workflow", "path", path, "error", err)
-
-			continue
-		}
-
-		if !exists {
+		if _, ok := present[path]; !ok {
 			continue
 		}
 

--- a/pkg/github/retired_test.go
+++ b/pkg/github/retired_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,26 +14,43 @@ import (
 	"github.com/smykla-skalski/.github/pkg/logger"
 )
 
-// testClient points a client at a stub API that reports the given paths as
-// present and answers 404 for everything else.
-func testClient(t *testing.T, present []string) *Client {
+// testClient points a client at a stub API whose .github/workflows directory
+// holds the given paths. calls counts the requests it served.
+func testClient(t *testing.T, present []string, calls *int) *Client {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			*calls++
+		}
+
 		path := r.URL.Path
 		if i := strings.Index(path, "/contents/"); i >= 0 {
 			path = path[i+len("/contents/"):]
 		}
 
-		if !slices.Contains(present, path) {
+		if path != workflowsDir {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(w, `{"message": "Not Found"}`)
 
 			return
 		}
 
-		fmt.Fprintf(w, `{"type":"file","name":%q,"path":%q,"encoding":"base64","content":%q}`,
-			path, path, base64.StdEncoding.EncodeToString([]byte("on:\n")))
+		// A repository with no workflows directory at all
+		if present == nil {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message": "Not Found"}`)
+
+			return
+		}
+
+		entries := make([]string, 0, len(present))
+		for _, p := range present {
+			entries = append(entries,
+				fmt.Sprintf(`{"type":"file","name":%q,"path":%q}`, path, p))
+		}
+
+		fmt.Fprintf(w, "[%s]", strings.Join(entries, ","))
 	}))
 	t.Cleanup(server.Close)
 
@@ -44,6 +60,28 @@ func testClient(t *testing.T, present []string) *Client {
 	}
 
 	return &Client{Client: gh, log: logger.New("error")}
+}
+
+// The listing is what makes this cheap. A fetch per retired name would cost one
+// request per name on every sync of every repository, for as long as the check
+// exists, and the usual answer is that there is nothing to delete.
+func TestCheckRetiredWorkflowsCostsOneRequest(t *testing.T) {
+	var calls int
+
+	stats := &FileSyncStats{MergedFiles: make(map[string]string)}
+	client := testClient(t, []string{".github/workflows/test.yml"}, &calls)
+
+	changes := checkRetiredWorkflows(
+		context.Background(), logger.New("error"), client, "org", "repo", stats,
+	)
+
+	if len(changes) != 0 {
+		t.Errorf("changes = %d, want 0", len(changes))
+	}
+
+	if calls != 1 {
+		t.Errorf("requests = %d, want 1", calls)
+	}
 }
 
 func TestCheckRetiredWorkflows(t *testing.T) {
@@ -92,7 +130,7 @@ func TestCheckRetiredWorkflows(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stats := &FileSyncStats{MergedFiles: make(map[string]string)}
-			client := testClient(t, tt.present)
+			client := testClient(t, tt.present, nil)
 
 			changes := checkRetiredWorkflows(
 				context.Background(), logger.New("error"), client, "org", "repo", stats,


### PR DESCRIPTION
## Motivation

Two things, one of which is blocking the other.

`checkRetiredWorkflows` fetched each retired path separately, so every file sync spent four contents requests per repository asking whether files that are usually absent are absent. The check stays in place long after the last repository is clean, and by then the answer is always that there is nothing to delete.

The blocking part: the deletion landed under a squashed `chore(sync):` title, which semantic-release reads as no release. dotsync never published a new version, `action.yml` still pins 1.15.12, and the sync workflows run that image - so nothing would have been deleted however many syncs ran. This change is typed to release, which ships the deletion with it.

## Implementation

One listing of `.github/workflows` answers all four paths at once. A repository with no workflows directory costs the same single request and returns nothing.

## Verification

The existing five cases still pass against the listing-based stub. Added a case asserting the whole check costs exactly one request against a repository whose workflows are all unrelated - the case that will run thousands of times and find nothing.

`go build`, `go test ./...` and `task lint:go` all clean.
