### PR TITLE
fix(labels): migrate pending CI names

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -110,6 +110,10 @@
   color: "#fef2c0"
   description: "Pending CI - merge commit"
 
+- name: "smyklot:pending:ci:service"
+  color: "#fef2c0"
+  description: "Pending CI owned by the Smyklot service"
+
 - name: "smyklot:pending:ci:squash"
   color: "#fef2c0"
   description: "Pending CI - squash merge"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -106,17 +106,29 @@
   color: "#0e8a16"
   description: "Organization-wide file and label synchronization"
 
-- name: "smyklot:pending-ci"
+- name: "smyklot:pending:ci"
   color: "#fef2c0"
   description: "Pending CI - merge commit"
 
-- name: "smyklot:pending-ci:squash"
+- name: "smyklot:pending:ci:squash"
   color: "#fef2c0"
   description: "Pending CI - squash merge"
 
-- name: "smyklot:pending-ci:rebase"
+- name: "smyklot:pending:ci:rebase"
   color: "#fef2c0"
   description: "Pending CI - rebase merge"
+
+- name: "smyklot:pending:ci:required"
+  color: "#fef2c0"
+  description: "Pending required CI - merge commit"
+
+- name: "smyklot:pending:ci:squash:required"
+  color: "#fef2c0"
+  description: "Pending required CI - squash merge"
+
+- name: "smyklot:pending:ci:rebase:required"
+  color: "#fef2c0"
+  description: "Pending required CI - rebase merge"
 
 # =============================================================================
 # Review labels - indicate review requirements

--- a/.github/scripts/migrate-smyklot-pending-ci-labels.sh
+++ b/.github/scripts/migrate-smyklot-pending-ci-labels.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository="${1:?repository is required}"
+dry_run="${2:-false}"
+
+migrations=(
+  'smyklot:pending-ci|smyklot:pending:ci'
+  'smyklot:pending-ci:squash|smyklot:pending:ci:squash'
+  'smyklot:pending-ci:rebase|smyklot:pending:ci:rebase'
+  'smyklot:pending-ci:required|smyklot:pending:ci:required'
+  'smyklot:pending-ci:squash:required|smyklot:pending:ci:squash:required'
+  'smyklot:pending-ci:rebase:required|smyklot:pending:ci:rebase:required'
+)
+
+label_path() {
+  jq -rn --arg label "$1" '$label | @uri'
+}
+
+label_exists() {
+  local label
+  label="$(label_path "$1")"
+  gh api --silent "repos/${repository}/labels/${label}" >/dev/null 2>&1
+}
+
+merge_label_assignments() {
+  local old_label="$1"
+  local new_label="$2"
+  local issue
+
+  while IFS= read -r issue; do
+    [[ -n "$issue" ]] || continue
+    jq -nc --arg label "$new_label" '{labels: [$label]}' |
+      gh api --silent --method POST "repos/${repository}/issues/${issue}/labels" --input -
+  done < <(
+    gh api --paginate --method GET "repos/${repository}/issues" \
+      -f state=all -f labels="$old_label" -f per_page=100 --jq '.[].number'
+  )
+}
+
+for migration in "${migrations[@]}"; do
+  old_label="${migration%%|*}"
+  new_label="${migration#*|}"
+  if ! label_exists "$old_label"; then
+    continue
+  fi
+  if [[ "$dry_run" == "true" ]]; then
+    echo "would migrate ${repository}: ${old_label} -> ${new_label}"
+    continue
+  fi
+
+  old_path="$(label_path "$old_label")"
+  if label_exists "$new_label"; then
+    merge_label_assignments "$old_label" "$new_label"
+    gh api --silent --method DELETE "repos/${repository}/labels/${old_path}"
+    echo "merged ${repository}: ${old_label} -> ${new_label}"
+  else
+    gh api --silent --method PATCH "repos/${repository}/labels/${old_path}" \
+      -f new_name="$new_label"
+    echo "renamed ${repository}: ${old_label} -> ${new_label}"
+  fi
+done

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - ".github/labels.yml"
+      - ".github/scripts/migrate-smyklot-pending-ci-labels.sh"
       - ".github/workflows/sync-labels.yml"
       - "action.yml"
   workflow_dispatch:
@@ -80,6 +81,14 @@ jobs:
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repo.name }}
+
+      - name: Migrate Smyklot pending CI labels
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: >-
+          .github/scripts/migrate-smyklot-pending-ci-labels.sh
+          "${{ github.repository_owner }}/${{ matrix.repo.name }}"
+          "${{ inputs.dry_run || 'false' }}"
 
       - name: Sync labels to repository
         uses: ./


### PR DESCRIPTION
# Summary

- Replace the legacy `smyklot:pending-ci:*` catalog entries with the complete `smyklot:pending:ci:*` label family
- Preserve existing issue and pull request assignments during the organization-wide migration

## Motivation

Smyklot now writes `smyklot:pending:ci:*` labels, but the organization catalog still provisions the former names. Creating the new labels alone would leave both formats in repositories that preserve extra labels.

## Implementation information

- Rename a legacy label in place when its canonical replacement is absent
- Transfer every assignment before deleting a legacy label when both names exist
- Run the idempotent migration before the normal organization label sync and honor workflow dry runs
- Validate the changed workflow with `mise exec -- actionlint .github/workflows/sync-labels.yml`
- Validate the migration script with `bash -n`
- Confirm the live Smyklot repository migration plan in dry-run mode